### PR TITLE
Bug fixed: Calling UI methods on background threads

### DIFF
--- a/UniBBS/BoardListViewController.m
+++ b/UniBBS/BoardListViewController.m
@@ -51,7 +51,6 @@
     [sheet showFromBarButtonItem:self.navigationItem.rightBarButtonItem animated:YES];
 }
 
-
 - (void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex
 {
     if (buttonIndex == actionSheet.cancelButtonIndex) {
@@ -77,7 +76,7 @@
             [self.view insertSubview:indicator aboveSubview:self.tableView];
             indicator.center = self.view.center;
             [indicator startAnimating];
-            [self performSelectorInBackground:@selector(loadData:) withObject:indicator];
+            [self loadData:indicator];
         }
             break;
         default:
@@ -118,20 +117,24 @@
     indicator.center = self.view.center;
     [indicator startAnimating];
     
-    [self performSelectorInBackground:@selector(loadData:) withObject:indicator];
+    [self loadData:indicator];
 }
 
-- (void) loadData:(UIActivityIndicatorView*) indicator {
-    if ([self.title isEqualToString:@"分类讨论区"]) {
-        wholeBoardList = [self.boardExplorer getWholeBoardList];
-    }
-    categaryBoardList = [self.boardExplorer getBoardList];
-    
-    self.boardList = categaryBoardList;
-  
-    [self.tableView reloadData];
-    [indicator stopAnimating];
-    [indicator removeFromSuperview];
+- (void)loadData:(UIActivityIndicatorView*)indicator {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        if ([self.title isEqualToString:@"分类讨论区"]) {
+            wholeBoardList = [self.boardExplorer getWholeBoardList];
+        }
+        categaryBoardList = [self.boardExplorer getBoardList];
+        
+        self.boardList = categaryBoardList;
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.tableView reloadData];
+            [indicator stopAnimating];
+            [indicator removeFromSuperview];
+        });
+    });
 }
 
 - (BOOL)searchDisplayController:(UISearchDisplayController *)controller shouldReloadTableForSearchString:(NSString *)searchString


### PR DESCRIPTION
原代码将会在后台更新完 list 后调用`[tableView reloadData]`等方法.在非主线程调用 UI 方法将会导致闪退.本 pr 修复了`BoardListViewController.m`里的该类问题.